### PR TITLE
Fix header overlap on page load

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -115,6 +115,7 @@ html {
     display: flex;
     align-items: center;
     overflow: hidden;
+    padding-top: 80px; /* Add padding to account for fixed navbar */
 }
 
 .hero-overlay {
@@ -386,6 +387,7 @@ footer {
     .hero-section {
         min-height: 80vh;
         text-align: center;
+        padding-top: 70px; /* Adjust padding for mobile navbar */
     }
     
     .display-3 {
@@ -416,6 +418,10 @@ footer {
 @media (max-width: 576px) {
     .navbar-brand {
         font-size: 1.2rem;
+    }
+    
+    .hero-section {
+        padding-top: 60px; /* Adjust padding for smaller mobile screens */
     }
     
     .display-3 {


### PR DESCRIPTION
Add top padding to the hero section to prevent content overlap with the fixed-top navbar.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6dede1d-56a7-48aa-ab18-24273aa3face"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6dede1d-56a7-48aa-ab18-24273aa3face"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

